### PR TITLE
add plugin option for hash length and algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ module.exports = {
     ["snowpack-plugin-content-hash", {
       exts: [".js", ".jsx"], // Extensions of files to be affected by this plugin. Note: only .js or .jsx are valid extensions.
       silent: true, // Provide log output during build process. Default: true.
+      hashLength: 8, // Specify the max length of the resulting hash string. Defaults to 0 for the full length.
+      hashAlgorithm: "sha256", // Specify the hash algorithm. Defaults to md5.
     }],
   ],
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,8 +16,8 @@ const defaultExt = ['js', 'jsx']
 const htmlFileDefault = '/index.html'
 const defaultMount = '__dist__'
 
-const createReference = async file => {
-  const hash = await createHashFromFile(file).then(hash => hash)
+const createReference = async (file, opts) => {
+  const hash = await createHashFromFile(file, opts).then(hash => hash)
   // Get file extension
   // Create complete new file path
   const result = {
@@ -68,7 +68,7 @@ const plugin = (snowpackConfig, pluginOptions) => {
       * wanted file extensions, within the build dir.
       */
       const files = await recursive(buildDirectory).then(files => files)
-      const promiseReferenceFiles = files.map(file => createReference(file))
+      const promiseReferenceFiles = files.map(file => createReference(file, pluginOptions))
       const referenceFiles = await Promise.all(promiseReferenceFiles).then(res => res)
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,10 @@
 const crypto = require('crypto')
 const fs = require('fs');
 
-const createHashFromFile = filePath => new Promise(resolve => {
-  const hash = crypto.createHash('md5');
-  fs.createReadStream(filePath).on('data', data => hash.update(data)).on('end', () => resolve(hash.digest('hex')));
+const createHashFromFile = (filePath, { hashLength, hashAlgorithm } = {}) => new Promise(resolve => {
+  const hash = crypto.createHash(hashAlgorithm || 'md5');
+  const substr = value => hashLength ? value.substring(0, hashLength) : value;
+  fs.createReadStream(filePath).on('data', data => hash.update(data)).on('end', () => resolve(substr(hash.digest('hex'))));
 });
 
 const extractDirInPath = _path => {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -11,6 +11,21 @@ describe('createHashFromFile', () => {
     const hash = await createHashFromFile(file).then(hash => hash)
     expect(hash).toEqual("7f20daec21535b94bf62ba0dec2811bf")
   })
+  it('should create a content-based sha256 hash of a file', async () => {
+    const file = `${path.join(__dirname, '__mock__/__dist__/index.js')}`
+    const hash = await createHashFromFile(file, {hashAlgorithm: 'sha256'}).then(hash => hash)
+    expect(hash).toEqual("88eb55e8b7794c617aa19480fec8895f57fb100ec5018d48dcb54ce96cc5de62")
+  })
+  it('should create an 8 character long content-based sha256 hash of a file', async () => {
+    const file = `${path.join(__dirname, '__mock__/__dist__/index.js')}`
+    const hash = await createHashFromFile(file, {hashAlgorithm: 'sha256', hashLength: 8}).then(hash => hash)
+    expect(hash).toEqual("88eb55e8")
+  })
+  it('should create a full length content-based sha128 hash of a file', async () => {
+    const file = `${path.join(__dirname, '__mock__/__dist__/index.js')}`
+    const hash = await createHashFromFile(file, {hashAlgorithm: 'sha512', hashLength: 0}).then(hash => hash)
+    expect(hash).toEqual("d21837e57e8dbb543caa0ef793844833687a15483fbb8d17d2cf1fecbce53248d845d7927bae99cb154480cf1070e683288417d1fd3a384010aacaa2fb03cb99")
+  })
 })
 describe('extractDirInPath', () => {
   it('should return an object with arr and str', async () => {


### PR DESCRIPTION
Add two plugin options: `hashLength` and `hashAlgorithm` to modify the resulting hash string appended to filenames.