### PR TITLE
fix(plugin): fixed getMountSrc function to return the right path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snowpack-plugin-content-hash",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -50,7 +50,9 @@ const getMountSrc = mountData => {
   for (const key in mountData) {
     console.log(key, extractDirInPath(key).dir)
     if (extractDirInPath(key).dir === 'src') {
-      return `${mountData[key]}`
+      return Object.keys(mountData[key] || {}).find((i) => i === 'url')
+        ? `${mountData[key].url}`
+        : `${mountData[key]}`;
     }
   }
   return ''


### PR DESCRIPTION
it seems in the new version the shape of the object has been changed `{ url: /dist, static: false, resolve: true }`. So this function needs to be updated to return the right value, otherwise it returns [object][object]